### PR TITLE
Fix global-uniqueness of weight characteristics

### DIFF
--- a/pet-adoption-api/src/main/java/petadoption/api/models/Weight.java
+++ b/pet-adoption-api/src/main/java/petadoption/api/models/Weight.java
@@ -7,6 +7,12 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
+@Table(
+    name = "weight",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "characteristic_id"})
+    }
+)
 public class Weight {
 
     @Id
@@ -20,6 +26,7 @@ public class Weight {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToOne
+    @ManyToOne
+    @JoinColumn(name = "characteristic_id")
     private Characteristic characteristic;
 }

--- a/pet-adoption-api/src/main/java/petadoption/api/services/RecEngineService.java
+++ b/pet-adoption-api/src/main/java/petadoption/api/services/RecEngineService.java
@@ -30,14 +30,7 @@ public class RecEngineService {
         this.userRepository = userRepository;
         this.petRepository = petRepository;
     }
-
-    public void addWeight(List<Weight> weights, Characteristic characteristic){
-        Weight weight = new Weight();
-        weight.setCharacteristic(characteristic);
-        weight.setWeight(1);
-        weights.add(weight);
-    }
-
+    
     public void addWeight(Characteristic characteristic, boolean liked, User user){
         Weight weight = new Weight();
         weight.setCharacteristic(characteristic);
@@ -45,16 +38,6 @@ public class RecEngineService {
         weight.setUser(user);
         user.getWeights().add(weight);
     }
-
-    public Map<Characteristic, Weight> convertListToWeightMap(List<Weight> weights) {
-        return weights.stream()
-                .collect(Collectors.toMap(
-                        Weight::getCharacteristic,
-                        Function.identity(),
-                        (existing, replacement) -> existing //keeps the first entry encountered
-                ));
-    }
-
 
     @Transactional
     public String likePet(User userFromSession, Optional<Pet> petDetail) {

--- a/pet-generator/initsql-characteristic-generator.js
+++ b/pet-generator/initsql-characteristic-generator.js
@@ -119,6 +119,20 @@ const breedToCharacteristicMap = {
   'Poodle': ['Curly fur', 'Tufted tip tail', 'Floppy ears', 'Slender body']
 }
 
+const breedToAPIBreedMap = {
+  'Labrador': 'labrador',
+  'Golden Retriever': 'retriever/golden',
+  'German Shepherd': 'germanshepherd',
+  'Chihuahua': 'chihuahua',
+  'Bulldog': 'bulldog',
+  'Shih Tzu': 'shihtzu',
+  'Beagle': 'beagle',
+  'Dachshund': 'dachshund',
+  'Boxer': 'boxer',
+  'Poodle': 'poodle'
+}
+
+
 const characteristics = [...`(1, 'Short fur'),
 (2, 'Medium fur'),
 (3, 'Long fur'),
@@ -175,5 +189,34 @@ for(let i = 0; i < dogBreeds.length; i++){
 }
 insertStrings = insertStrings.substring(0, insertStrings.length-1); // trim trailing comma
 insertStrings+=';'
-
 console.log(insertStrings);
+
+
+let imageInsertStrings = `INSERT INTO pet_images(pet_id, image_url) VALUES`
+
+const vals = [];
+const promises = [];
+for(let i = 0; i < dogBreeds.length; i++){
+	const dogId = i+1;
+
+	promises.push((async () => {
+		for(let j = 0; j < 4; j++){
+			const image_url = (await (await fetch(`https://dog.ceo/api/breed/${breedToAPIBreedMap[dogBreeds[i]]}/images/random`)).json()).message
+			console.log(image_url);
+			vals.push(`\n(${dogId}, '${image_url}'),`)
+		}
+	})());
+}
+
+
+await Promise.all(promises);
+vals.sort((a, b) => {
+	console.log(`a: ${a.match(/\((?<a>\d+)/).groups['a']}`)
+	return Number(a.match(/\((?<a>\d+)/).groups['a']) - Number(b.match(/\((?<a>\d+)/).groups['a']);
+});
+
+imageInsertStrings += vals.join('');
+imageInsertStrings = imageInsertStrings.substring(0, imageInsertStrings.length-1); // trim trailing comma
+imageInsertStrings+=';'
+
+console.log(imageInsertStrings);


### PR DESCRIPTION
Restructures the JPA annotations to properly map characteristics onto weights. Weights are now unique per-user, instead of globally within the table.

Tested with swiping/liking on multiple users