### PR TITLE
Change to known password for demo ac

### DIFF
--- a/docker/sql/init.sql
+++ b/docker/sql/init.sql
@@ -225,7 +225,7 @@ INSERT INTO users (
     website
 ) VALUES (
     1,
-    '$2a$10$qLPzS/zi.Fya7pAcbRtkmu3oDh63rIovhEvg1S.fI9hDeMAsPbDAy',
+    '$2a$10$pnyZ/M4.GhXThDMoVtnp1.QnhJZZtj69qkeqj/MUahuwUGh9l2MoC',
     'happy_paws@adoptcenter.com',
     'Lisa',
     'Mendez',


### PR DESCRIPTION
did you know if you type your password in a github comment, it gets automatically censored to asterisks? like if i try to type this password, it just shows up as ********. Try it in the comments!